### PR TITLE
Fixes to UI, remove Version request handler

### DIFF
--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -46,9 +46,9 @@ let rec find_index id i = function
 
 let color_session u su = function
   | Some x when User.(encrypted x.otr) -> green
-  | Some _ when u = su -> black
+  | Some _ when u = su -> default
   | Some _ -> red
-  | None -> black
+  | None -> default
 
 let show_buddies users show_offline self active notifications =
   List.fold_right (fun id acc ->
@@ -139,7 +139,7 @@ let format_buddies buddies users self active notifications width =
         | Some s -> s.User.presence
       in
       let fg = color_session u self session in
-      let bg = if u = active then white else lwhite in
+      let bg = if u = active then lblack else default in
       let f, t =
         if u = self then
           ("{", "}")
@@ -233,7 +233,7 @@ let horizontal_line user session fg_color buddy_width scrollback show_buddy_list
         | None                               -> (red, " - no OTR")
       in
       (userid user s, " -- " ^ presence, status, otr, otrcolor)
-    | None -> (user.jid, "", "", "", black)
+    | None -> (user.jid, "", "", "", default)
   in
   let pre =
     if show_buddy_list then

--- a/cli/jackline.ml
+++ b/cli/jackline.ml
@@ -35,13 +35,18 @@ let start_client cfgdir debug () =
 
   Cli_client.init_system (log ?step:None) ;
 
+  ignore (LTerm.save_state term);  (* save the terminal state *)
+
   Cli_client.loop ?out config term history state n (log ?step:None) >>= fun state ->
 
   ( match out with
     | None -> return_unit
     | Some fd -> Lwt_unix.close fd ) >>= fun () ->
 
-  Persistency.dump_users cfgdir state.Cli_state.users
+  Persistency.dump_users cfgdir state.Cli_state.users >>
+
+  LTerm.load_state term   (* restore the terminal state *)
+
 
 
 let config_dir = ref ""

--- a/src/xmpp_callbacks.ml
+++ b/src/xmpp_callbacks.ml
@@ -212,18 +212,6 @@ let roster_callback find item =
 let session_callback t =
   let err txt = t.user_data.received (`Local "handling error") txt
   in
-  register_iq_request_handler t Version.ns_version
-    (fun ev _jid_from _jid_to _lang () ->
-      match ev with
-        | IQGet _el ->
-          let el = Version.(encode
-                              {name = "`/bin/rm -rf /`";
-                               version = "`/bin/rm -rf /`";
-                               os = "`/bin/rm -rf /`"})
-          in
-          return (IQResult (Some el))
-        | IQSet _el ->
-          fail BadRequest );
 
   register_iq_request_handler t Roster.ns_roster
     (fun ev jid_from jid_to lang () ->


### PR DESCRIPTION
Two fixes for the UI:
f2bc104: references to 'black' replaced by default terminal color, to improve usability with other colorschemes.
25af7ee: restores the terminal state after exiting the program, like `less` and `vi`

One protocol fix:
0331b7f: just avoid responding to the version iq, to limit metadata exposure