### PR TITLE
Export notification state to file for use with systray

### DIFF
--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -564,7 +564,10 @@ let rec loop ?out (config : Config.t) term hist state network log =
          Cli_commands.exec ?out command state config log force_redraw >>= fun () ->
          loop ?out config term hist state network log
        else
-         ( begin
+         (
+ (*          do_write_session_state state.session_state_out_channel Quit ;
+           Lwt_io.close_out state.session_state_out_channel ;*)
+           begin
              match !xmpp_session with
                | None -> return_unit
                | Some x ->

--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -466,7 +466,7 @@ let activate_user state active =
        state.notifications     <- List.filter (fun a -> a <> active) state.notifications 
        in if old_notifications >  List.length state.notifications then
          (* go from Notifications -> Connected *)
-         update_session_state_file state !xmpp_session
+         update_notification_state_file state !xmpp_session
      ) ;
      state.window_mode         <- BuddyList ;
      force_redraw ())
@@ -570,7 +570,7 @@ let rec loop ?out (config : Config.t) term hist state network log =
          loop ?out config term hist state network log
        else
          (
-           do_write_session_state state.config_directory Quit ;
+           flush_notification_state_file state.config_directory Quit ;
            begin
              match !xmpp_session with
                | None -> return_unit

--- a/cli/cli_commands.ml
+++ b/cli/cli_commands.ml
@@ -193,7 +193,7 @@ let handle_connect ?out state config log redraw failure =
     User.Users.replace state.users user.User.jid user ;
     session
   and update_session user session =
-    User.replace_session state.users user session ;
+    User.replace_session state.users user session
   and find_inc_fp user resource raw_fp =
     let fp = User.find_raw_fp user raw_fp in
     let resources =

--- a/cli/cli_commands.ml
+++ b/cli/cli_commands.ml
@@ -158,14 +158,14 @@ let handle_connect ?out state config log redraw failure =
     else
       state.notifications <- jid :: state.notifications
   in
-  let update_session_state () =
-    update_session_state_file state !xmpp_session
+  let update_notification_state_file () =
+    update_notification_state_file state !xmpp_session
   in
   let notify indicate u =
     let jid = u.User.jid in
     if indicate then maybe_notify jid ;
     User.Users.replace state.users jid u ;
-    update_session_state () ;
+    update_notification_state_file () ;
     redraw ()
   and remove jid =
     User.Users.remove state.users jid ;
@@ -175,14 +175,13 @@ let handle_connect ?out state config log redraw failure =
       state.last_active_contact <- state.user ;
     redraw ()
   and received dir txt =
-    log (dir, txt) ;
-    update_session_state ()
+    log (dir, txt)
   and message user dir enc txt =
     let user = User.insert_message user dir enc true txt in
     let jid = user.User.jid in
     User.Users.replace state.users jid user ;
     maybe_notify jid ;
-    update_session_state () ;
+    update_notification_state_file () ;
     redraw ()
   and find = User.find state.users
   and find_or_create = User.find_or_create state.users
@@ -192,11 +191,9 @@ let handle_connect ?out state config log redraw failure =
     let otr_config = config.Config.otr_config in
     let user, session = User.find_or_create_session user resource otr_config in
     User.Users.replace state.users user.User.jid user ;
-    update_session_state () ;
     session
   and update_session user session =
     User.replace_session state.users user session ;
-    update_session_state ()
   and find_inc_fp user resource raw_fp =
     let fp = User.find_raw_fp user raw_fp in
     let resources =
@@ -232,7 +229,7 @@ let handle_disconnect state s msg =
   Xmpp_callbacks.close s >>= fun () ->
   xmpp_session := None ;
   msg "session error" "disconnected" ;
-  update_session_state_file state !xmpp_session ;
+  update_notification_state_file state !xmpp_session ;
   return_unit
 
 let send_status s presence status priority failure =

--- a/cli/cli_state.ml
+++ b/cli/cli_state.ml
@@ -1,3 +1,4 @@
+open Lwt_io
 
 type display_mode =
   | BuddyList
@@ -9,10 +10,26 @@ let next_display_mode = function
   | FullScreen -> Raw
   | Raw        -> BuddyList
 
+type session_status =
+  | Connected
+  | Disconnected
+  | Notifications
+  | Quit
+  | Default
+
+let string_of_session_status = function
+  | Connected     -> "connected"
+  | Disconnected  -> "disconnected"
+  | Notifications -> "notifications"
+  | Quit          -> "quit"
+  | Default       -> "undefinedDEFAULT"
+
 type ui_state = {
   config_directory            : string                    ; (* set initially *)
   user                        : string                    ; (* set initially *)
   resource                    : string                    ; (* set initially *)
+
+  session_state_out_channel   : Lwt_io.output_channel Lwt.t  ; (* file handle for session_status reporting*)
 
   users                       : User.users                ; (* read from disk, extended by xmpp callbacks *)
 
@@ -28,12 +45,58 @@ type ui_state = {
   mutable last_status         : (User.direction * string) ; (* internal use only *)
 }
 
+let get_session_state ui_state xmpp_session = match xmpp_session with
+  | None   -> Disconnected
+  | Some _ ->
+    begin try let _ = List.hd ui_state.notifications
+         in Connected
+    with
+    | _  -> Notifications
+    end
+
+let do_write_session_state oc session_state =
+  (* this function should be private; not included in the mli *)
+  let s  = string_of_session_status session_state in
+  lwt _ = 
+  Lwt.bind
+    (Lwt.bind
+      (Lwt.bind
+        (Lwt.return oc)
+        (fun oc -> Lwt_io.set_position oc Int64.zero; Lwt.return oc)
+      )
+      (fun oc -> Lwt_io.write_line oc s; Lwt.return oc)
+    )
+    (fun oc -> Lwt.join [(Lwt_io.flush oc)])
+  in
+    Lwt.return_unit
+
+let update_session_state_file ui_state xmpp_session =
+  lwt oc = ui_state.session_state_out_channel in
+  let s  = get_session_state ui_state xmpp_session
+  in
+   lwt _ = do_write_session_state oc s in
+   Lwt.return_unit
+
 let empty_ui_state config_directory user resource users =
+  (*let _ = Lwt.join [(do_write_session_state session_state_out_channel Disconnected)] in*)
+  let session_state_out_channel =
+  let x =
+     lwt fd = 
+      Lwt_unix.openfile
+        (config_directory ^ Filename.dir_sep ^ "ui.state")
+        Lwt_unix.[ O_WRONLY ; O_TRUNC ; O_CREAT]
+        0o640 (* user: RW, group: r, other: no access *)
+     in
+       Lwt.return (Lwt_io.of_fd Output fd)
+    in x
+  in
   let last_status = (`Local "", "") in
   {
     config_directory                ;
     user                            ;
     resource                        ;
+
+    session_state_out_channel       ;
 
     users                           ;
 
@@ -55,3 +118,4 @@ let add_status state dir msg =
   User.Users.replace state.users state.user user
 
 let (xmpp_session : Xmpp_callbacks.user_data Xmpp_callbacks.XMPPClient.session_data option ref) = ref None
+


### PR DESCRIPTION
Generates some warning messages because of the Lwt.bind-freakshow going on in the file writing function.
I've still no idea how Lwt is supposed to be used, but this works for my purposes. Rewrites welcome :-)