### PR TITLE
Dont whitelist carriage return

### DIFF
--- a/src/xmpp_callbacks.ml
+++ b/src/xmpp_callbacks.ml
@@ -37,6 +37,8 @@ let validate_utf8 txt =
        (* filter <0x20 except if it's tab (x09) or newline (x0a) *)
       | '\x09' | '\x0a'
           -> c
+      | '\x0d' (* CR, turn it into a LF / newline *)
+          -> '\n'
       | '\x00' .. '\x1f'
           -> '?'
       | _ -> c

--- a/src/xmpp_callbacks.ml
+++ b/src/xmpp_callbacks.ml
@@ -34,10 +34,12 @@ type user_data = {
 
 let validate_utf8 txt =
   let txt = String.map (fun c -> match c with
-      | '\x00' .. '\x08' |'\x0b'|'\x0c'| '\x0e' .. '\x1f'
-       (* filter <0x20 except if it's tab (x09) or newline (x0a/x0d) *)
-        -> '?'
-      | c -> c
+       (* filter <0x20 except if it's tab (x09) or newline (x0a) *)
+      | '\x09' | '\x0a'
+          -> c
+      | '\x00' .. '\x1f'
+          -> '?'
+      | _ -> c
     ) txt in
   try let _ = Zed_utf8.validate txt in txt
   with Zed_utf8.Invalid (err, esc) -> err ^ ": " ^ esc


### PR DESCRIPTION
While on the subject of the filtering function (https://github.com/hannesm/jackline/issues/8#issuecomment-70255293), I think this patch should be applied to convert CRs into regular newlines instead.