### PR TITLE
Add second timestamp to chat messages (and remove month in turn to limit...

### DIFF
--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -170,9 +170,9 @@ let format_messages msgs =
   let printmsg { direction ; encrypted ; received ; timestamp ; message ; _ } =
     let lt = Unix.localtime timestamp in
     let time =
-      Printf.sprintf "%02d-%02d %02d:%02d "
-        (succ lt.Unix.tm_mon) lt.Unix.tm_mday
-        lt.Unix.tm_hour lt.Unix.tm_min
+      Printf.sprintf "%02d %02d:%02d:%02d "
+        lt.Unix.tm_mday
+        lt.Unix.tm_hour lt.Unix.tm_min lt.Unix.tm_sec
     in
     let en = if encrypted then "O" else "-" in
     let pre = match direction with


### PR DESCRIPTION
... the length of the date prompt).

I'm often annoyed by the lack of seconds in the timestamps, especially when comparing shown messages with the XMPP debug log. On the other hand, I find the "month" display a bit pointless.
What do you think about merging this change?