### PR TITLE
export notification state to file

### DIFF
--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -476,6 +476,8 @@ let activate_user state active =
      state.scrollback          <- 0 ;
      state.notifications       <- List.filter (fun a -> a <> active) state.notifications ;
      state.window_mode         <- BuddyList ;
+     if 0 == List.length state.notifications then
+       Lwt.async (fun () -> Lwt_mvar.put state.notify_mvar Clear) ;
      force_redraw ())
 
 let navigate_message_buffer state direction =

--- a/cli/cli_commands.ml
+++ b/cli/cli_commands.ml
@@ -196,6 +196,7 @@ let handle_connect ?out state config log redraw failure =
     if List.mem jid state.notifications || state.active_contact = jid then
       ()
     else
+      Lwt.async (fun () -> Lwt_mvar.put state.notify_mvar Notifications) ;
       state.notifications <- jid :: state.notifications
   in
   let notify indicate u =
@@ -271,6 +272,7 @@ let handle_connect ?out state config log redraw failure =
   | Some s ->
     xmpp_session := Some s ;
     Lwt.async (fun () -> Xmpp_callbacks.parse_loop s) ;
+    Lwt.async (fun () -> Lwt_mvar.put state.notify_mvar Connected) ;
     Xmpp_callbacks.restart_keepalive s
 
 let handle_disconnect s users msg =
@@ -589,6 +591,7 @@ let exec ?out input state config log redraw =
   let err = msg "error" in
   let failure reason =
     xmpp_session := None ;
+    Lwt_mvar.put state.notify_mvar Disconnected >>= fun () ->
     msg "session error" (Printexc.to_string reason)
   in
   let contact = User.Users.find state.users state.active_contact in
@@ -620,7 +623,8 @@ let exec ?out input state config log redraw =
   (* disconnect *)
   | ("disconnect", _) ->
     ( match !xmpp_session with
-      | Some x -> handle_disconnect x state.users (msg ?prefix:None)
+      | Some x -> handle_disconnect x state.users (msg ?prefix:None) >>= fun () ->
+        Lwt_mvar.put state.notify_mvar Disconnected
       | None   -> err "not connected" )
 
   (* own things *)

--- a/cli/jackline.ml
+++ b/cli/jackline.ml
@@ -66,6 +66,8 @@ let start_client cfgdir debug () =
     | None -> return_unit
     | Some fd -> Lwt_unix.close fd ) >>= fun () ->
 
+  Lwt_mvar.put state.Cli_state.notify_mvar Cli_state.Quit >>= fun () ->
+
   Persistency.dump_users cfgdir state.Cli_state.users >>= fun () ->
 
   LTerm.load_state term   (* restore the terminal state *)


### PR DESCRIPTION
another attempt at hannesm/jackline#38

    if the file "notification.state" exists in the configuration
    directory, it will overwritten with
	"disconnected" or
	"connected" or
	"connected_notifications" or
	"disconnected_notifications"
    when connection state or pending notifications change
    on exit, "quit" will be