### PR TITLE
notifications: retain notifications for active contact

### DIFF
--- a/cli/cli_commands.ml
+++ b/cli/cli_commands.ml
@@ -193,7 +193,7 @@ let handle_connect ?out state config log redraw failure =
   in
 
   let maybe_notify jid =
-    if List.mem jid state.notifications || state.active_contact = jid then
+    if List.mem jid state.notifications || (state.active_contact = jid && state.scrollback = 0) then
       ()
     else
       state.notifications <- jid :: state.notifications ;


### PR DESCRIPTION
notifications: retain notifications for active contact if the user is scrolled up and haven't read the new messages.

The change to line 478 in `cli/cli_client.ml` is not strictly needed atm since the current behavior is to reset scrollback when the user switches the active contact, but I hope it serves as reminder to keep track of notifications when at some nice point in time we will have user-specific scrollback state.
