### PR TITLE
Display the offending sha256 fingerprint (in hex) of a certificate wh…

### DIFF
--- a/bin/jackline.ml
+++ b/bin/jackline.ml
@@ -7,7 +7,16 @@ let start_client cfgdir debug () =
 
   Printexc.register_printer (function
       | Tls_lwt.Tls_alert x -> Some ("TLS alert: " ^ Tls.Packet.alert_type_to_string x)
-      | Tls_lwt.Tls_failure f -> Some ("TLS failure: " ^ Tls.Engine.string_of_failure f)
+      | Tls_lwt.Tls_failure f -> Some ("TLS failure: " ^
+        begin match f with
+        | `Error (`AuthenticationFailure (`InvalidFingerprint cert)) ->
+            "AuthenticationFailure: InvalidFingerprint: " ^
+            begin match
+              Hex.of_cstruct (X509.fingerprint cert `SHA256)
+            with `Hex s -> s end
+        | _ ->
+            Tls.Engine.string_of_failure f
+        end )
       | _ -> None) ;
 
   Nocrypto_entropy_lwt.initialize () >>= fun () ->


### PR DESCRIPTION
…en fingerprint pinning encounters an unexpected fingerprint instead of dumping raw sexp

Depends on the merging of this pull request which exposes the `X509.fingerprint` function:

https://github.com/mirleft/ocaml-x509/pull/66
