### PR TITLE
Treat leading "/*" and "// " as text (not command)

### DIFF
--- a/cli/cli_input.ml
+++ b/cli/cli_input.ml
@@ -205,7 +205,10 @@ let read_terminal term mvar input_mvar () =
                          s)
                     else
                       s)
-              else if String.get input 0 = '/' then
+              else if String.get input 0 = '/'
+                 (* copy-paste: treat as text if line starts with "/*" or "// " *)
+              && not String.(length input >= 2 && get input 1 = '*')
+              && not String.(length input >= 3 && sub input 1 2 = "/ ") then
                 match String.trim input with
                 | "/quit" -> Lwt.return (`Quit s)
                 | cmd ->


### PR DESCRIPTION
Treat lines beginning with `/*` and `// ` as regular text to accomodate less error-prone copy-pasting of C code comments.

Resolves #108
