### PR TITLE
fix "*** connecting ***" debug message to show actual hostname

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,8 @@ action ()
 {
     case $1 in
         default)
-            GIT=$(git log --abbrev-commit --oneline -1 | tr -d '/')
+            GIT="$(git log --abbrev-commit --oneline -1 | tr -d '/' \
+                 | sed -e 's:\\:\\\\\\\\:g' -e 's#"#\\\\"#g' )"
             DIRTY=$(git status -bs --porcelain | wc -l)
             if [ $DIRTY -eq 1 ]; then
                 cat src/utils.ml | sed -e "s/%%VERSION%%/$GIT/g" > src/utils.ml.tmp

--- a/cli/cli_state.ml
+++ b/cli/cli_state.ml
@@ -148,7 +148,9 @@ module Connect = struct
            Unix.string_of_inet_addr inet_addr ^ " on port " ^ string_of_int port
         | Unix.ADDR_UNIX str -> str
       in
-      selflog ui_mvar "connecting" ("to " ^ domain ^ " (" ^ addr ^ ")")
+      selflog ui_mvar "connecting" ("to " ^ domain ^
+        " (" ^ (match hostname with None -> "" | Some n -> n ^ ": ")
+        ^ addr ^ ")")
     in
     Xmpp_callbacks.resolve hostname port domain >>= fun sa ->
     report sa >|= fun () ->


### PR DESCRIPTION
fix "*** connecting *** to ..." to display (hostname) rather than the server name (`domain`) from the jid