### PR TITLE
Better GUI integration for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ status line
 - How do I prevent jackline from doing DNS lookups? -- Interactive configuration or specify `(hostname ("146.255.57.229"))` in `config.sexp`.
 - The server certificate does not match the server name, how do I fix this? -- Interactive configuration or specify `(cert_hostname ("blabla.com"))` in `config.sexp`.
 - Keys do not work on MacOSX -- [This](https://github.com/timothybasanov/terminal-app-function-keys#full-list-of-all-bindings) might be useful.
-- I want to receive notifications. -- A hook script can be defined during interactive configuration or `(notification_callback (/my/favorite/script.sh))` in `config.sexp`.  It is executed with two (or more) arguments: the local user's jabber id, a summary of the state of jackline; see `cli/cli_state.ml` search for `module Notify` for details.
+- I want to receive notifications. -- A hook script can be defined during interactive configuration or `(notification_callback (/my/favorite/script.sh))` in `config.sexp`.  It is executed with three (or more) arguments: the local user's jabber id, a summary of the state of jackline, the event type that caused this execution, and perhaps other things; see `cli/cli_state.ml` search for `module Notify` for details.
 - I want a systray icon. -- there are two projects, [posiputt/jackification](https://github.com/posiputt/jackification), and [cfcs/misc](https://github.com/cfcs/misc/blob/master/jackline_systray.py)
 - I want to have notifications on MacOSX. - Andrej wrote [a script](https://github.com/schoeke/notline) using terminal notifier; otherwise [this guide](https://gist.github.com/prebenlm/5562656) might help.
 - Support? -- join us at jackline@conference.jabber.ccc.de

--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ highest priority.
 
 When a new message is received, this is indicated by blinking of the
 contact, a prepended `*` (or `☀` in case of collapsed contact), a blue
-`#` in the bottom left corner, execution of `notification_callback`,
-and modification of `notification.state`.
+`#` in the bottom left corner and execution of `notification_callback`.
 
 A message is sent to the active contact by typing it followed by
 `return`.
@@ -183,7 +182,7 @@ status line
 - How do I prevent jackline from doing DNS lookups? -- Interactive configuration or specify `(hostname ("146.255.57.229"))` in `config.sexp`.
 - The server certificate does not match the server name, how do I fix this? -- Interactive configuration or specify `(cert_hostname ("blabla.com"))` in `config.sexp`.
 - Keys do not work on MacOSX -- [This](https://github.com/timothybasanov/terminal-app-function-keys#full-list-of-all-bindings) might be useful.
-- I want to receive notifications. -- There are two ways at the moment: `notification.state` contains the current state (written on every change) and a hook script can be defined during interactive configuration or `(notification_callback (/my/favorite/script.sh))` in `config.sexp`.  It is executed with two arguments: the jabber id and state.
+- I want to receive notifications. -- A hook script can be defined during interactive configuration or `(notification_callback (/my/favorite/script.sh))` in `config.sexp`.  It is executed with two (or more) arguments: the local user's jabber id, a summary of the state of jackline; see `cli/cli_state.ml` search for `module Notify` for details.
 - I want a systray icon. -- there are two projects, [posiputt/jackification](https://github.com/posiputt/jackification), and [cfcs/misc](https://github.com/cfcs/misc/blob/master/jackline_systray.py)
 - I want to have notifications on MacOSX. - Andrej wrote [a script](https://github.com/schoeke/notline) using terminal notifier; otherwise [this guide](https://gist.github.com/prebenlm/5562656) might help.
 - Support? -- join us at jackline@conference.jabber.ccc.de

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ highest priority.
 
 When a new message is received, this is indicated by blinking of the
 contact, a prepended `*` (or `☀` in case of collapsed contact), a blue
-`#` in the bottom left corner and execution of `notification_callback`.
+`#` in the bottom left corner, execution of `notification_callback` and
+(if given) the nth file descriptor specified by --fd-nfy.
 
 A message is sent to the active contact by typing it followed by
 `return`.

--- a/bin/jackline.ml
+++ b/bin/jackline.ml
@@ -93,12 +93,12 @@ let start_client cfgdir debug unicode fd_gui fd_nfy () =
 
   let ui_mvar = Lwt_mvar.create_empty () in
 
-  let state_mvar =
+  let notify_mvar =
     Cli_state.Notify.notify_writer myjid config.Xconfig.notification_callback fd_nfy
   in
   let _ = Cli_state.Notify.gui_focus_reader fd_gui ui_mvar in
-  let connect_mvar = Cli_state.Connect.connect_me config ui_mvar state_mvar users in
-  let state = Cli_state.empty_state cfgdir config users connect_mvar state_mvar in
+  let connect_mvar = Cli_state.Connect.connect_me config ui_mvar notify_mvar users in
+  let state = Cli_state.empty_state cfgdir config users connect_mvar notify_mvar in
 
   let greeting =
     "multi user chat support: see you at /join jackline@conference.jabber.ccc.de (use ArrowUp key); \
@@ -135,7 +135,7 @@ let start_client cfgdir debug unicode fd_gui fd_nfy () =
 
   closing () >>= fun () ->
 
-  Lwt_mvar.put state.Cli_state.state_mvar Cli_state.Quit >>= fun () ->
+  Lwt_mvar.put state.Cli_state.notify_mvar Cli_state.Quit >>= fun () ->
 
   (* cancel history dumper *)
   Lwt_engine.stop_event hist_dumper ;

--- a/bin/jackline.ml
+++ b/bin/jackline.ml
@@ -94,8 +94,7 @@ let start_client cfgdir debug unicode () =
   let ui_mvar = Lwt_mvar.create_empty () in
 
   let state_mvar =
-    let file = Filename.concat cfgdir "notification.state" in
-    Cli_state.Notify.notify_writer myjid config.Xconfig.notification_callback file
+    Cli_state.Notify.notify_writer myjid config.Xconfig.notification_callback
   in
   let connect_mvar = Cli_state.Connect.connect_me config ui_mvar state_mvar users in
   let state = Cli_state.empty_state cfgdir config users connect_mvar state_mvar in

--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -99,14 +99,14 @@ let format_buddy state width s contact resource =
   let a =
     if isactive state jid then
       A.(st reverse)
-    else if isnotified state jid then
+    else if has_notifications state jid then
       A.(st blink)
     else
       A.empty
   in
   let a = A.(a ++ buddy_to_color (Contact.color contact resource)) in
   let first =
-    match isnotified state jid, Contact.expanded contact with
+    match has_notifications state jid, Contact.expanded contact with
     | true, true -> I.char a '*' 1 1
     | false, false -> I.char a (if potentially_visible_resource state contact then '+' else ' ') 1 1
     | true, false -> Char.star a 1

--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -312,7 +312,7 @@ let render_state (width, height) state =
     and bottom =
       let self = self state in
       let status =
-        let notify = List.length state.notifications > 0
+        let notify = has_any_notifications state
         and log = Contact.preserve_messages active
         and mysession = selfsession state
         in

--- a/cli/cli_input.ml
+++ b/cli/cli_input.ml
@@ -10,7 +10,7 @@ let navigate_message_buffer state direction =
   | Down, 0 -> state
   | Down, n ->
     let s = { state with scrollback = pred n } in
-    if s.scrollback = 0 then notified s else s
+    if s.scrollback = 0 then maybe_clear s else s
   | Up, n -> { state with scrollback = succ n }
 
 let history state dir =

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -56,4 +56,4 @@ let validate_utf8 txt =
   let nln = `Readline 0x000A in
   loop (Uutf.decoder ~nln ~encoding:`UTF_8 (`String txt)) (Buffer.create (String.length txt))
 
-let version = "%%VERSION%%"
+let version = {__version__|%%VERSION%%|__version__}


### PR DESCRIPTION
Add the ability to communicate with the parent process via file descriptors / pipes. This allows us to provide more accurate notifications. Also remove notifications.state as suggested earlier.

There's a few TODO items remaining, which I'll complete if you like the general direction of this PR.

There should be no increase in privacy leaks to the surrounding processes - I didn't change the information that jackline sends out (only added another sending *mechanism*), and I added the ability to receive a minor amount of information which I believe is necessary to make it work more nicely with GUIs (and allows us to avoid sending out contact ids, as I suggested earlier). I understand this might be contentious though, so I await your input.

The fd-based approach was inspired by dialog(1) and gpg(1). It's a bit easier to code with than using unix sockets. I can also do the latter if desired though.