### PR TITLE
`/rooms` to discover chatrooms, `/join` does not require an argument

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -6,15 +6,9 @@ B _build/src
 B _build/cli
 B _build/bin
 
-PKG erm_xmpp
-PKG otr
-PKG tls
-PKG tls.lwt
-PKG lwt
-PKG sexplib
-PKG hex
-PKG nocrypto
+PKG erm_xmpp otr tls tls.lwt
+PKG lwt sexplib hex nocrypto
 PKG notty notty.lwt
-PKG ptime
-PKG ptime.clock.os
+PKG ptime ptime.clock.os
 PKG ppx_sexp_conv
+PKG astring

--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -13,8 +13,16 @@ let print_time ~now ~tz_offset_s timestamp =
   else
     Printf.sprintf "%02d-%02d %02d:%02d " m d hh mm
 
+let st_kind = function
+  | `Chat | `GroupChat -> `Message
+  | `Presence -> `Info
+
+let st_to_a = function
+  | `Message -> A.empty
+  | `Info -> A.(fg (gray 18))
+
 let format_log tz_offset_s now log =
-  let { User.direction ; timestamp ; message ; _ } = log in
+  let { User.direction ; timestamp ; message ; kind ; _ } = log in
   let time = print_time ~now ~tz_offset_s timestamp in
   let from = match direction with
     | `From jid -> Xjid.jid_to_string jid ^ ":"
@@ -22,9 +30,9 @@ let format_log tz_offset_s now log =
     | `Local (_, x) -> "*** " ^ x ^ " ***"
     | `To _ -> ">>>"
   in
-  (A.empty, time ^ from ^ " " ^ message)
+  (st_to_a (st_kind kind), time ^ from ^ " " ^ message)
 
-let format_message tz_offset_s now self buddy resource { User.direction ; encrypted ; received ; timestamp ; message ; _ } =
+let format_message tz_offset_s now self buddy resource { User.direction ; encrypted ; received ; timestamp ; message ; kind ; _ } =
   let time = print_time ~now ~tz_offset_s timestamp
   and style, pre =
     match buddy with
@@ -66,10 +74,13 @@ let format_message tz_offset_s now self buddy resource { User.direction ; encryp
         Utils.option "" (fun x -> "(" ^ x ^ ") ") show_res
       in
       (style, r ^ pre)
-  and to_style = function
-    | `Default -> A.empty
-    | `Highlight -> A.(st bold)
-    | `Underline -> A.(st underline)
+  and to_style st =
+    match st, st_kind kind with
+    | `Default, x -> st_to_a x
+    | `Highlight, `Message -> A.(st bold)
+    | `Highlight, `Info -> st_to_a `Info
+    | `Underline, `Message -> A.(st underline)
+    | `Underline, `Info -> A.(st underline ++ st_to_a `Info)
   in
   let p, msg =
     if String.length message >= 3 && String.sub message 0 3 = "/me" then

--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -248,13 +248,13 @@ let render_state (width, height) state =
       if s + 10 > height then 0 else s
     in
     if lh = 0 then
-      (0, height - 2)
+      (0, height - 3)
     else
       (lh, height - lh - 3)
   and buddy_width, chat_width =
     let b = state.buddy_width in
     match state.window_mode with
-    | BuddyList -> (b, width - b - 1)
+    | BuddyList -> if b + 20 > width then (0, width) else (b, width - b - 1)
     | FullScreen | Raw -> (0, width)
   in
 
@@ -330,15 +330,15 @@ let render_state (width, height) state =
         and mysession = selfsession state
         in
         status_line self mysession notify log a width
+      and hline = horizontal_line active resource a state.scrollback width
       in
       if log_height = 0 then
-        status
+        I.(hline <-> status)
       else
         let logs =
           let msgs = Utils.take_rev log_height self.User.message_history in
           let l = render_wrapped_list true width (List.map logfmt msgs) in
           I.vsnap ~align:`Bottom log_height l
-        and hline = horizontal_line active resource a state.scrollback width
         in
         I.(hline <-> logs <-> status)
     in

--- a/cli/cli_commands.ml
+++ b/cli/cli_commands.ml
@@ -145,11 +145,20 @@ let completion s input =
       (match List.filter (fun f -> might_match f cmd) cmds with
        | [] -> []
        | [_] when Commands.mem commands cmd -> (Commands.find commands cmd).subcommands s
-       | xs -> List.map (fun x -> drop ~max:(pred l) x) xs)
+       | xs -> List.map (drop ~max:(pred l)) xs)
     | (cmd, Some arg) when Commands.mem commands cmd ->
       let command = Commands.find commands cmd in
       List.map (fun x -> drop ~max:(pred l) (cmd ^ " " ^ x))
         (List.filter (fun f -> might_match f arg) (command.subcommands s))
+    | _ -> []
+  else if l > 0 then
+    match active s with
+    | `Room r ->
+      List.map (drop ~max:l)
+        (List.filter
+           (Astring.String.is_prefix ~affix:input)
+           (List.map (fun m -> m.Muc.nickname)
+              (List.filter (fun m -> m.Muc.presence <> `Offline) r.Muc.members)))
     | _ -> []
   else
     []

--- a/cli/cli_commands.ml
+++ b/cli/cli_commands.ml
@@ -484,6 +484,7 @@ let handle_connect p c_mvar =
                { Muc.nickname = nick ; jid = real_jid ; affiliation ; role ; presence ; status } ::
                List.filter (fun m -> m.Muc.nickname <> nick) r.Muc.members
            in
+           (* XXX: should inform user (join/leave message) *)
            Contact.replace_room state.contacts { r with Muc.members }) ;
         Lwt_mvar.put state.contact_mvar (`Room r) >>= fun () ->
         Lwt.return (`Ok state)

--- a/cli/cli_commands.ml
+++ b/cli/cli_commands.ml
@@ -387,16 +387,14 @@ let handle_connect p c_mvar =
     let pre = match old, now with
       | `Offline, `Online -> "joined"
       | `Offline, `Free -> "joined"
-      | `Offline, `DoNotDisturb -> "joined (dnd)"
-      | `Offline, `Away -> "joined (away)"
-      | `Offline, `ExtendedAway -> "joined (xa)"
+      | `Offline, x -> "joined (" ^ User.presence_to_string x ^ ")"
       | _, `Offline -> "left"
       | x, y ->
         let oldc = User.presence_to_char x
         and nowc = User.presence_to_char y
         and nows = User.presence_to_string y
         in
-        "[" ^ oldc ^ ">" ^ nowc ^ "] (" ^ nows ^ ")"
+        oldc ^ "->" ^ nowc ^ " (" ^ nows ^ ")"
     in
     let status = Utils.option "" (fun x -> " - " ^ x) status in
     pre ^ status

--- a/cli/cli_commands.ml
+++ b/cli/cli_commands.ml
@@ -45,6 +45,8 @@ let _ =
 
   new_command
     "logheight" "/logheight [number]" "adjusts height of log to n" (fun _ -> []) ;
+  new_command
+    "buddywidth" "/buddywidth [number]" "adjusts width of buddy list to n" (fun _ -> []) ;
 
   (* global roster commands *)
   new_command
@@ -1052,6 +1054,13 @@ let exec input state contact isself p =
         | Some log_height when log_height >= 0 -> ok { state with log_height }
         | _ -> err "not a positive number")
     | ("logheight", _), _ -> err "requires argument"
+
+    (* buddywidth *)
+    | ("buddywidth", Some x), _ ->
+      (match try Some (int_of_string x) with Failure _ -> None with
+        | Some buddy_width when buddy_width >= 0 -> ok { state with buddy_width }
+        | _ -> err "not a positive number")
+    | ("buddywidth", _), _ -> err "requires argument"
 
     | ("go", Some x), _ ->
       (match Xjid.string_to_jid x with

--- a/cli/cli_input.ml
+++ b/cli/cli_input.ml
@@ -298,7 +298,11 @@ let read_terminal term mvar input_mvar () =
               let pre =
                 match Cli_commands.completion s input with
                 | [] -> pre
-                | [x] -> pre @ str_to_char_list (x ^ " ")
+                | [x] ->
+                  if String.length input > 0 && String.get input 0 = '/' then
+                    pre @ str_to_char_list (x ^ " ")
+                  else
+                    pre @ str_to_char_list (x ^ ": ")
                 | x::xs ->
                   let shortest = List.fold_left (fun l x -> min l (String.length x)) (String.length x) xs in
                   let rec prefix idx =

--- a/cli/cli_input.ml
+++ b/cli/cli_input.ml
@@ -126,7 +126,13 @@ let send_msg t state active_user message =
           let ctx, out, user_out = Otr.Engine.send_otr ctx msg in
           let user = User.update_otr u session ctx in
           Contact.replace_user state.contacts user ;
-          (`Full (bare, session.User.resource), Some session, out, user_out, None)
+          let jid, session =
+            if session.User.resource = "" then
+              (`Bare bare, None)
+            else
+              (`Full (bare, session.User.resource), Some session)
+          in
+          (jid, session, out, user_out, None)
   in
   maybe_send ?kind jid session out user_out
 

--- a/cli/cli_state.ml
+++ b/cli/cli_state.ml
@@ -57,11 +57,11 @@ type state = {
   input : input ;
 }
 
-let add_status state dir msg =
+let add_status ?kind state dir msg =
   match Contact.find_user state.contacts (fst state.config.Xconfig.jid) with
   | None -> assert false
   | Some self ->
-     let self = User.insert_message self dir false true msg in
+     let self = User.insert_message ?kind self dir false true msg in
      Contact.replace_user state.contacts self
 
 let active state =

--- a/src/user.ml
+++ b/src/user.ml
@@ -209,6 +209,7 @@ let jid_of_direction = function
 type chatkind = [
   | `Chat
   | `GroupChat
+  | `Presence
 ] [@@deriving sexp]
 
 type message = {
@@ -320,8 +321,8 @@ let message ?(timestamp = Ptime_clock.now ()) ?(kind = `Chat) direction encrypte
 let new_message user message =
   { user with message_history = message :: user.message_history }
 
-let insert_message ?timestamp u dir enc rcvd msg =
-  let message = message ?timestamp dir enc rcvd msg in
+let insert_message ?timestamp ?kind u dir enc rcvd msg =
+  let message = message ?timestamp ?kind dir enc rcvd msg in
   new_message u message
 
 let encrypted = Otr.State.is_encrypted

--- a/src/user.ml
+++ b/src/user.ml
@@ -287,14 +287,6 @@ let active_session user =
   let sorted = List.sort compare_session user.active_sessions
   and not_subscribed = List.mem user.subscription [`From ; `None]
   in
-  (* XXX: here be dragons: consider the other to be subscribed (i.e. in the roster),
-     but the s2s communication slightly broken: ends up in a pretty useless
-     dialogue (sending to bare, not having a otr context)
-
-     maybe a valuable strategy is to look whether R went (recently) from XXX to
-     offline?  what we really want to prevent is sending messages into the
-     nirvana (now that randomized resources are the way to go!?)
-   *)
   match List.filter (fun x -> x.presence <> `Offline) sorted, sorted with
   | x :: _, _ -> Some x
   | [], x :: _ when not_subscribed -> Some x

--- a/src/user.ml
+++ b/src/user.ml
@@ -285,7 +285,7 @@ let new_user ~jid ?(name=None) ?(groups=[]) ?(subscription=`None) ?(otr_fingerpr
   { bare_jid = jid ; name ; groups ; subscription ; properties ; otr_fingerprints ; preserve_messages ; active_sessions ; message_history ; input_buffer ; readline_history ; otr_custom_config ; expand ; self ; history_position }
 
 let active_session user =
-  let sorted = List.sort compare_session user.active_sessions in
+  let sorted = sorted_sessions user in
   match List.filter (fun x -> x.presence <> `Offline) sorted, sorted with
   | x :: _, _ -> Some x
   | [], x :: _ -> Some x

--- a/src/user.ml
+++ b/src/user.ml
@@ -35,8 +35,8 @@ let presence_to_string = function
   | `Online       -> "online"
   | `Free         -> "free"
   | `Away         -> "away"
-  | `DoNotDisturb -> "do not disturb"
-  | `ExtendedAway -> "extended away"
+  | `DoNotDisturb -> "dnd"
+  | `ExtendedAway -> "xa"
   | `Offline      -> "offline"
 
 let string_to_presence = function

--- a/src/user.ml
+++ b/src/user.ml
@@ -285,12 +285,10 @@ let new_user ~jid ?(name=None) ?(groups=[]) ?(subscription=`None) ?(otr_fingerpr
   { bare_jid = jid ; name ; groups ; subscription ; properties ; otr_fingerprints ; preserve_messages ; active_sessions ; message_history ; input_buffer ; readline_history ; otr_custom_config ; expand ; self ; history_position }
 
 let active_session user =
-  let sorted = List.sort compare_session user.active_sessions
-  and not_subscribed = List.mem user.subscription [`From ; `None]
-  in
+  let sorted = List.sort compare_session user.active_sessions in
   match List.filter (fun x -> x.presence <> `Offline) sorted, sorted with
   | x :: _, _ -> Some x
-  | [], x :: _ when not_subscribed -> Some x
+  | [], x :: _ -> Some x
   | _ -> None
 
 let oneline user =

--- a/src/user.mli
+++ b/src/user.mli
@@ -90,6 +90,7 @@ val jid_of_direction : direction -> Xjid.t
 type chatkind = [
   | `Chat
   | `GroupChat
+  | `Presence
 ]
 
 val chatkind_of_sexp : Sexplib.Type.t -> chatkind
@@ -146,7 +147,7 @@ val oneline : user -> string
 val oneline_with_session : user -> session -> string
 
 (* messages *)
-val insert_message : ?timestamp:Ptime.t -> user -> direction -> bool -> bool -> string -> user
+val insert_message : ?timestamp:Ptime.t -> ?kind:chatkind -> user -> direction -> bool -> bool -> string -> user
 val new_message : user -> message -> user
 
 (* convenience *)

--- a/src/xmpp_callbacks.ml
+++ b/src/xmpp_callbacks.ml
@@ -57,6 +57,8 @@ type user_data = {
   presence             : Xjid.t -> User.presence -> int -> string option -> unit Lwt.t ;
   group_presence       : Xjid.t -> User.presence -> string option -> Xep_muc.User.data -> unit Lwt.t ;
 
+  create_room          : Xjid.bare_jid -> bool -> unit Lwt.t ;
+
   (* this is to initialise all subscription information to `None before fetching the roster --
      this needs to be done, since a roster get will not return those not in your roster (and might have been modified by different client) *)
   reset_users          : unit -> unit Lwt.t ;


### PR DESCRIPTION
and presence and messages do not need to have a full jid, but a bare one is sufficient

...worked on this while using slack's broken xmpp gateway... pretty sad that they violate the rfc immensly
