### PR TITLE
More tweaks for notification logic

### DIFF
--- a/bin/jackline.ml
+++ b/bin/jackline.ml
@@ -96,7 +96,7 @@ let start_client cfgdir debug unicode fd_gui fd_nfy () =
   Cli_state.Notify.notify_writer myjid config.Xconfig.notification_callback fd_nfy >>= fun state_mvar ->
   Cli_state.Notify.gui_focus_reader fd_gui ui_mvar ;
   let connect_mvar = Cli_state.Connect.connect_me config ui_mvar state_mvar users in
-  let state = Cli_state.empty_state cfgdir config users connect_mvar state_mvar fd_gui in
+  let state = Cli_state.empty_state cfgdir config users connect_mvar state_mvar in
 
   let greeting =
     "multi user chat support: see you at /join jackline@conference.jabber.ccc.de (use ArrowUp key); \

--- a/bin/jackline.ml
+++ b/bin/jackline.ml
@@ -93,8 +93,8 @@ let start_client cfgdir debug unicode fd_gui fd_nfy () =
 
   let ui_mvar = Lwt_mvar.create_empty () in
 
-  Cli_state.Notify.notify_writer myjid config.Xconfig.notification_callback fd_nfy >>= fun state_mvar ->
-  Cli_state.Notify.gui_focus_reader fd_gui ui_mvar ;
+  Cli_state.Notify.notify_writer ui_mvar myjid config.Xconfig.notification_callback fd_nfy >>=
+  fun state_mvar -> Cli_state.Notify.gui_focus_reader fd_gui ui_mvar ;
   let connect_mvar = Cli_state.Connect.connect_me config ui_mvar state_mvar users in
   let state = Cli_state.empty_state cfgdir config users connect_mvar state_mvar in
 

--- a/cli/cli_state.ml
+++ b/cli/cli_state.ml
@@ -368,17 +368,13 @@ let random_string () =
   let rnd = Rng.generate 12 in
   Cstruct.to_string (Base64.encode rnd)
 
-let contact_has_user_focus state jid =
-  state.gui_has_focus && (isactive state jid)
-
 let notify state jid =
   let newstate =
-    if contact_has_user_focus state jid then
-      state
-    else if
+    if
       List.exists (Xjid.jid_matches jid) state.notifications ||
-      (Xjid.jid_matches state.active_contact jid && state.scrollback = 0)
+      (state.gui_has_focus && Xjid.jid_matches state.active_contact jid && state.scrollback = 0)
     then
+      (* no-op <=> already has notification || has focus from {parent gui, term window, scrolling} *)
       state
     else
       { state with notifications = jid :: state.notifications } in


### PR DESCRIPTION
TL;DR is that the previous behaviour was mostly fine. one just has to look for `notify_contact` in arg2 rather than `_notifications` in arg1. Example trace running without any `fd-gui`:

~~~~
disconnected disconnect
connected connect
connected_notifications notify_contact                  # message received on inactive contact
connected_notifications notify_contact
connected clear_all_notifications                       # visited all contacts
connected notify_contact clear_all_notifications        # message received on active contact
connected notify_contact clear_all_notifications        # and again
                                                        # now switching to a different contact
connected_notifications notify_contact                  # message received on previous contact, now inactive
connected_notifications notify_contact
connected clear_all_notifications                       # visited all contacts again
~~~~

More generally, if `fd-gui` is not set then jackline should behave assuming the parent gui is always in focus - I initialise `gui_has_focus` to `true` and no other place sets it to `false`.

I also fixed a few other minor things, more details in the commit messages.