### PR TITLE
Generate an otr_dsa if the rest of the config is there

### DIFF
--- a/bin/jackline.ml
+++ b/bin/jackline.ml
@@ -41,9 +41,14 @@ let start_client cfgdir debug unicode fd_gui fd_nfy () =
   let tc = Unix.(tcgetattr stdin) in
   Unix.(tcsetattr stdin TCSANOW { tc with c_isig = false ; c_ixon = false ; c_ixoff = false }) ;
 
-  Persistency.load_dsa cfgdir >>= fun dsa ->
+  let load_or_gen_dsa = Persistency.load_dsa cfgdir >>= function
+    | None ->
+      let dsa = Nocrypto.Dsa.generate `Fips1024 in
+      Persistency.dump_dsa cfgdir dsa >|= fun _ -> dsa
+    | Some dsa -> Lwt.return dsa
+  in
 
-  Persistency.load_config dsa cfgdir >>= (function
+  Persistency.load_config load_or_gen_dsa cfgdir >>= (function
       | None ->
         Cli_config.configure term () >>= fun config ->
         Persistency.dump_config cfgdir config >>= fun () ->

--- a/src/persistency.ml
+++ b/src/persistency.ml
@@ -97,10 +97,11 @@ let user_dir dir =
 let dump_config cfgdir cfg =
   write cfgdir config (Xconfig.store_config cfg)
 
-let load_config dsa cfg =
-  read cfg config >|= function
-  | Some x ->  Some (Xconfig.load_config dsa x)
-  | None   -> None
+let load_config load_dsa cfg =
+  read cfg config >>= function
+  | Some x -> load_dsa >|= fun dsa ->
+    Some (Xconfig.load_config (Some dsa) x)
+  | None   -> Lwt.return_none
 
 let dump_user cfgdir user =
   user_dir cfgdir >>= fun userdir ->


### PR DESCRIPTION
This lets you create new profiles by copying old ones, without having to go
through the slow manual configuration CLI.