### PR TITLE
fix #188 terminal cleanup problem

### DIFF
--- a/opam
+++ b/opam
@@ -25,7 +25,7 @@ depends: [
   "otr" {>= "0.2.1"}
   "astring"
   "ptime" {>= "0.8.0"}
-  "notty" {>= "0.2.0"}
+  "notty" {>= "0.2.2" & < "0.3.0" }
   "sexplib"
   "hex"
   "uchar"


### PR DESCRIPTION
fix #188 by putting a lower bound on the recent notty release which fixes the upstream problem, see https://github.com/pqwy/notty/issues/22

Tested on Mac OS (where the problem was fixed by this) and Linux (where I didn't have the problem, but tested that it didn't break anything obvious).