### PR TITLE
Add /ignore_presence

### DIFF
--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -303,8 +303,14 @@ let render_state (width, height) state =
           | None -> (fun id -> id)
           | Some x -> List.filter (fun { User.message ; _ } -> Astring.String.is_infix ~affix:x message)
         in
+        let presence_filter =
+          if state.ignore_presence
+          then List.filter (function { User.kind = `Presence ; _ } -> false
+                                   | _ -> true)
+          else (fun id -> id)
+        in
         let data = Utils.take_rev max
-            (List.filter mfilter (filter (Contact.messages active)))
+            (List.filter mfilter (presence_filter (filter (Contact.messages active))))
         in
         let image = render_wrapped_list strip chat_width (List.map fmt data) in
         let bottom = state.scrollback * main_height in

--- a/cli/cli_commands.ml
+++ b/cli/cli_commands.ml
@@ -44,6 +44,8 @@ let _ =
     "quit" "/quit" "exits this client" (fun _ -> []) ;
   new_command
     "filter" "/filter [val]" "display only messages which contain val (empty string resets filter)" (fun _ -> []) ;
+  new_command
+    "ignore_presence" "/ignore_presence" "hide presence updates (join, away, etc)" (fun _ -> []) ;
 
   new_command
     "logheight" "/logheight [number]" "adjusts height of log to n" (fun _ -> []) ;
@@ -1144,6 +1146,8 @@ let exec input state contact isself p =
     | ("disconnect", _), None   -> err "/disconnect: not connected"
 
     | ("filter", filter), _ -> ok { state with filter }
+
+    | ("ignore_presence", _), _ -> ok { state with ignore_presence = not state.ignore_presence }
 
     (* need connection *)
     | (x, _), None when List.mem x online -> err ("/" ^ x ^ ": not connected")

--- a/cli/cli_state.ml
+++ b/cli/cli_state.ml
@@ -53,6 +53,7 @@ type state = {
   log_height : int ;
   buddy_width : int ;
   filter : string option ;
+  ignore_presence : bool ;
 
   (* current input buffer *)
   input : input ;
@@ -363,6 +364,7 @@ let empty_state config_directory config contacts connect_mvar state_mvar =
     log_height          = 6         ;
     buddy_width         = 24        ;
     filter              = None      ;
+    ignore_presence     = false     ;
     input               = ([], [])  ;
     kill                = []
 }
@@ -495,6 +497,7 @@ let activate_contact state active =
         active_contact      = njid ;
         scrollback          = 0 ;
         filter              = None ;
+        ignore_presence     = false ;
         window_mode         = BuddyList ;
         input               = Contact.input_buffer now }
     in


### PR DESCRIPTION
This command toggles hiding all presence updates in buffers. I was missing this due to scrolling being broken in my terminal (I've since found out it was the terminal emulator using those keys for something else already), and in MUCs I find it's often full of noise from presence updates.

It's not very sophisticated. It's a global option for *all* presence updates. It could be more fine grained:
* Per chat,
* per presence update type.