### PR TITLE
Fix build for dns-client 4.5.0

### DIFF
--- a/_tags
+++ b/_tags
@@ -10,7 +10,7 @@ true : package(sexplib astring uchar ptime erm_xmpp lwt tls tls.lwt hex otr x509
 <src/persistency.ml>: package(lwt.unix)
 <src/xjid.{ml,mli}>: package(ppx_sexp_conv)
 <src/user.{ml,mli}>: package(ppx_sexp_conv ptime.clock.os)
-<src/xmpp_callbacks.ml>: package(dns-client.lwt mtime.clock.os)
+<src/xmpp_callbacks.ml>: package(dns-client.lwt)
 
 <cli/*>: package(notty lwt)
 <cli/cli_support.ml>: package(uutf uucp uuseg)

--- a/opam
+++ b/opam
@@ -29,7 +29,6 @@ depends: [
   "otr" {>= "0.2.1"}
   "astring"
   "ptime" {>= "0.8.0"}
-  "mtime"
   "notty" {>= "0.2.2"}
   "sexplib"
   "hex"
@@ -38,7 +37,7 @@ depends: [
   "uucp" {>= "2.0.0"}
   "uuseg" {>= "1.0.0"}
   "uutf" {>= "1.0.0"}
-  "dns-client" { >= "4.2.0" }
+  "dns-client" { >= "4.5.0" }
   "base64"
 ]
 synopsis: "Jackline - a minimalistic secure XMPP client"

--- a/pkg/META
+++ b/pkg/META
@@ -1,3 +1,3 @@
 description = "A terminal based xmpp client"
 version = "%%VERSION_NUM%%"
-requires = "erm_xmpp otr tls tls.lwt lwt sexplib hex nocrypto notty ptime ptime.clock.os ipaddr domain-name dns dns-client dns-client.lwt mtime.clock.os"
+requires = "erm_xmpp otr tls tls.lwt lwt sexplib hex nocrypto notty ptime ptime.clock.os ipaddr domain-name dns dns-client dns-client.lwt"

--- a/src/xmpp_callbacks.ml
+++ b/src/xmpp_callbacks.ml
@@ -391,7 +391,7 @@ let resolve ~(selflog:?kind:User.chatkind -> string -> string -> unit Lwt.t) (ho
     | Ok host -> match Domain_name.host host with
       | Error _ -> Lwt.return None
       | Ok host ->
-        let resolver = Dns_client_lwt.create ~clock:Mtime_clock.now_ns () in
+        let resolver = Dns_client_lwt.create () in
         Dns_client_lwt.gethostbyname resolver host >|= function
         | Result.Error _ -> None
         | Ok ip -> Some (Ipaddr.V4.to_string ip |> Unix.inet_addr_of_string)


### PR DESCRIPTION
Dns_client_lwt.create no longer requires a clock, this also makes the
mtime dependency obsolete.