### PR TITLE
Update documentation regarding Tor

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@ I (so far successfully) try to preserve three core properties:
 - once the initial configuration file (and private key and maybe password) is created, it will never be written to by jackline
 - jackline will never transmit any data or open a network connection unless initiated by you (this means no "autoconnect on startup", or "user is typing" indication sent).  There is an automated reconnect to the same server if the connection terminated.
 
-
-NB: jackline and
-[torsocks](https://trac.torproject.org/projects/tor/wiki/doc/torsocks) are
-friends: `torify jackline` works.
-
 ### Security and trusted code base
 
 The configuration file has to include the trust anchor for the server


### PR DESCRIPTION
`torify` and `torsocks` no longer work as `jackline` will tell you when you try to use them.

Are btw there any plans to support SOCKS proxies as a replacement in the future?