### PR TITLE
switch to displaying dates as soon as the day changes

### DIFF
--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -6,9 +6,12 @@ open Cli_state
 open Cli_support
 
 let print_time ~now ~tz_offset_s timestamp =
-  let daydiff, _ = Ptime.Span.to_d_ps (Ptime.diff now timestamp) in
+  let day_of_time t = match fst (Ptime.to_date_time ~tz_offset_s t) with
+    | (_, _, d) -> d
+  in
+  let daydiff = day_of_time now - day_of_time timestamp in
   let (_, m, d), ((hh, mm, ss), _) = Ptime.to_date_time ~tz_offset_s timestamp in
-  if daydiff = 0 then (* less than a day ago *)
+  if daydiff = 0 then (* same calendar day as now *)
     Printf.sprintf "%02d:%02d:%02d " hh mm ss
   else
     Printf.sprintf "%02d-%02d %02d:%02d " m d hh mm


### PR DESCRIPTION
Previously we switched to displaying dates as soon as 24h passed. This is however potentially confusing for users:

```
04-08 16:00 -O> Some message
17:00:00 -O> Some other message
```

Was "Some other message" sent today or yesterday? To answer this question the user must:

* Check the current time
* If it is after  17:00:00, it was today
* If it is before 17:00:00, it was yesterday

With the new behavior, we prefix the times with a date as soon as we cross the day border. This way it requires no awareness of the current time to determine on which day a message was received: All messages without a date are today, all messages with a date are yesterday or earlier.

Additionally the rendering of old messages changes only once per day. Previously it was kind of irritating if you were using jackline around the same time on multiple days without clearing the history since every once in a while a single message further up changes because its timestamp is suddenly rendered differently.