### PR TITLE
Adapt to tls 0.15.0

### DIFF
--- a/cli/cli_state.ml
+++ b/cli/cli_state.ml
@@ -250,11 +250,7 @@ module Connect = struct
           (let a =
              match config.Xconfig.authenticator with
              | `Trust_anchor x -> `Ca_file x
-             | `Fingerprint fp ->
-               let host =
-                 Domain_name.host_exn (Domain_name.of_string_exn certname)
-               in
-               `Hex_cert_fingerprints (`SHA256, [ host, fp ])
+             | `Fingerprint fp -> `Hex_cert_fingerprint (`SHA256, fp)
            in
            X509_lwt.authenticator a) >>= fun authenticator ->
           let kind, show = Xmpp_callbacks.presence_to_xmpp p in

--- a/jackline.opam
+++ b/jackline.opam
@@ -31,7 +31,7 @@ depends: [
   "ppx_sexp_conv" {build}
   "ppx_deriving" {>= "0.14.0"}
   "erm_xmpp" {>= "0.3"}
-  "tls" {>= "0.14.0"}
+  "tls" {>= "0.15.0"}
   "mirage-crypto-pk" {>= "0.8.3"}
   "x509" {>= "0.10.0"}
   "domain-name" {>= "0.2.0"}


### PR DESCRIPTION
`Hex_cert_fingerprints has been renamed to `Hex_cert_fingerprint and no
longer requires passing in a hostname.