### PR TITLE
Multiline paste

### DIFF
--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -275,18 +275,22 @@ let render_state (width, height) state =
 
       let split_lines lines =
         let line_of_list lst img =
-          Notty.Infix.(I.uchars A.empty (Array.of_list lst) <-> img) in
-        List.fold_right
-          (fun ch (line_acc, acc) ->
-             if Uchar.(equal (of_char '\n')) ch
-             then [], line_of_list line_acc acc
-             else ch::line_acc, acc)
-          lines ([], I.empty)
-        |> function | [], acc -> acc
-                    | last, img -> line_of_list last img
+          Notty.Infix.(I.uchars A.empty (Array.of_list lst) <-> img)
+        in
+        match
+          List.fold_right
+            (fun ch (line_acc, acc) ->
+               if Uchar.(equal (of_char '\n')) ch
+               then [], line_of_list line_acc acc
+               else ch::line_acc, acc)
+            lines ([], I.empty)
+        with
+        | [], acc -> acc
+        | last, img -> line_of_list last img
       in
       let iinp = split_lines pre
-      and iinp2 = split_lines post in
+      and iinp2 = split_lines post
+      in
       let r = match post with
         | [] ->
           let input = char_list_to_str pre in

--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -273,15 +273,15 @@ let render_state (width, height) state =
     let input, cursorc =
       let pre, post = state.input in
 
-      let split_lines lines : Notty.image =
+      let split_lines lines =
         let line_of_list lst img =
           Notty.Infix.(I.uchars A.empty (Array.of_list lst) <-> img) in
         List.fold_right
-          (fun ch (line_acc, acc: Uchar.t list * Notty.image) ->
+          (fun ch (line_acc, acc) ->
              if Uchar.(equal (of_char '\n')) ch
              then [], line_of_list line_acc acc
              else ch::line_acc, acc)
-          (lines:Uchar.t list) ([], I.empty)
+          lines ([], I.empty)
         |> function | [], acc -> acc
                     | last, img -> line_of_list last img
       in

--- a/cli/cli_client.ml
+++ b/cli/cli_client.ml
@@ -273,13 +273,20 @@ let render_state (width, height) state =
     let input, cursorc =
       let pre, post = state.input in
 
-      let iinp =
-        let inp = Array.of_list pre in
-        I.uchars A.empty inp
-      and iinp2 =
-        let inp2 = Array.of_list post in
-        I.uchars A.empty inp2
+      let split_lines lines : Notty.image =
+        let line_of_list lst img =
+          Notty.Infix.(I.uchars A.empty (Array.of_list lst) <-> img) in
+        List.fold_right
+          (fun ch (line_acc, acc: Uchar.t list * Notty.image) ->
+             if Uchar.(equal (of_char '\n')) ch
+             then [], line_of_list line_acc acc
+             else ch::line_acc, acc)
+          (lines:Uchar.t list) ([], I.empty)
+        |> function | [], acc -> acc
+                    | last, img -> line_of_list last img
       in
+      let iinp = split_lines pre
+      and iinp2 = split_lines post in
       let r = match post with
         | [] ->
           let input = char_list_to_str pre in

--- a/cli/cli_support.ml
+++ b/cli/cli_support.ml
@@ -209,32 +209,44 @@ let char_list_to_str xs =
   Array.iter (Uutf.Buffer.add_utf_8 buf) inp ;
   Buffer.contents buf
 
-let readline_input = function
-  | `Key (`Backspace, []) ->
+let readline_input : [ `Key of Notty.Unescape.key
+                     | `Mouse of Notty.Unescape.mouse
+                     | `Resize of int * int
+                     | `Paste of [`End | `Start] ] -> 'b =
+  let pasting = ref false in
+  (* ^-- TODO this keeps state across calls, not so nice*)
+  fun event -> match event, !pasting with
+  | `Paste (`Start | `End as mode), _ ->
+    pasting := (mode = `Start);
+    `Ok (fun pre_post -> pre_post)
+  | `Key ((`Enter, []) : Notty.Unescape.key), true ->
+    `Ok (fun (pre, post) -> (pre@[Uchar.of_char '\n'], post))
+  | `Key (`Backspace, []), false ->
     `Ok (fun (pre, post) ->
         match List.rev pre with
         | [] -> (pre, post)
         | _::tl -> (List.rev tl, post))
-  | `Key (`Delete, []) ->
+  | `Key (`Delete, []), false ->
     `Ok (fun (pre, post) ->
         match post with
         | [] -> (pre, post)
         | _::tl -> (pre, tl))
-  | `Key (`Home, []) -> `Ok (fun (pre, post) -> [], pre @ post)
-  | `Key (`End, []) -> `Ok (fun (pre, post) -> pre @ post, [])
-  | `Key (`Arrow `Right, []) ->
+  | `Key (`Home, []), false -> `Ok (fun (pre, post) -> [], pre @ post)
+  | `Key (`End, []), false -> `Ok (fun (pre, post) -> pre @ post, [])
+  | `Key (`Arrow `Right, []), false ->
     `Ok (fun (pre, post) ->
         match post with
         | [] -> (pre, post)
         | hd::tl -> (pre @ [hd], tl))
-  | `Key (`Arrow `Left, []) ->
+  | `Key (`Arrow `Left, []), false ->
     `Ok (fun (pre, post) ->
         match List.rev pre with
         | [] -> ([], post)
         | hd::tl -> (List.rev tl, hd :: post))
-  | `Key (`ASCII chr, []) -> `Ok (fun (pre, post) -> pre @ [Notty.Unescape.uchar (`ASCII chr)], post)
-  | `Key (`Uchar chr, []) -> `Ok (fun (pre, post) -> pre @ [chr], post)
-  | k -> `Unhandled k
+  | `Key (`ASCII chr, []), _ ->
+    `Ok (fun (pre, post) -> pre @ [Notty.Unescape.uchar (`ASCII chr)], post)
+  | `Key (`Uchar chr, []), _ -> `Ok (fun (pre, post) -> pre @ [chr], post)
+  | (`Key _ | `Resize _ | `Mouse _) as k, _  -> `Unhandled k
 
 let split_forward post =
   let inp, middle = match post with

--- a/cli/cli_support.ml
+++ b/cli/cli_support.ml
@@ -212,15 +212,15 @@ let char_list_to_str xs =
 let readline_input : [ `Key of Notty.Unescape.key
                      | `Mouse of Notty.Unescape.mouse
                      | `Resize of int * int
-                     | `Paste of [`End | `Start] ] -> 'b =
+                     | `Paste of Notty.Unescape.paste ] -> 'b =
   let pasting = ref false in
   (* ^-- TODO this keeps state across calls, not so nice*)
   fun event -> match event, !pasting with
   | `Paste (`Start | `End as mode), _ ->
     pasting := (mode = `Start);
-    `Ok (fun pre_post -> pre_post)
-  | `Key ((`Enter, []) : Notty.Unescape.key), true ->
-    `Ok (fun (pre, post) -> (pre@[Uchar.of_char '\n'], post))
+    `Ok Fun.id
+  | `Key (`Enter, []), true ->
+    `Ok (fun (pre, post) -> (pre @ [Uchar.of_char '\n'], post))
   | `Key (`Backspace, []), false ->
     `Ok (fun (pre, post) ->
         match List.rev pre with


### PR DESCRIPTION
This commit adds support for multi-line pasting into a single message (so if you paste 10 lines you get one message that contains newlines as opposed to 10 individual messages).
I think that's easier to read, and it's easier to copy-paste from.

I've been using this for a few years and it's been stable and worked nicely for me, but I haven't tested it on top of a recent `main` head. As noted in the commit message, the local editing could be implemented more nicely: with this patch it's still one single line where the newlines "show up" as invisible characters that you can delete/insert (by pasting), but it doesn't implement a multi-line edit buffer.

It looks like I also added another thing, the
```
`Cc = Uucp.Gc.general_category chr 
```
check that turns control characters into the unicode replacement character. It could be a separate PR, but splitting them out is awkward since they touch the same code. Happy to strip that part if you don't like it. :-)

ping @hannesm 